### PR TITLE
fix(ci): resolve release-plz workflow parse failure

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -16,42 +16,50 @@ jobs:
   release-pr:
     name: release-pr
     runs-on: ubuntu-latest
+    env:
+      RELEASE_PLZ_PAT: ${{ secrets.RELEASE_PLZ_PAT }}
+      RELEASE_PLZ_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Warn when RELEASE_PLZ_TOKEN is unset
-        if: ${{ secrets.RELEASE_PLZ_TOKEN == '' }}
+      - name: Warn when release-plz PAT is unset
         run: |
-          echo "::warning::RELEASE_PLZ_TOKEN is not set; tag-driven workflows may not trigger."
-          echo "::warning::Set RELEASE_PLZ_TOKEN (PAT with repo contents/pull_request write) for full automation."
+          if [ -z "${RELEASE_PLZ_PAT}" ] && [ -z "${RELEASE_PLZ_TOKEN}" ]; then
+            echo "::warning::Neither RELEASE_PLZ_PAT nor RELEASE_PLZ_TOKEN is set; tag-driven workflows may not trigger."
+            echo "::warning::Set RELEASE_PLZ_PAT (preferred) as a PAT with repo contents + pull_request write permissions."
+          fi
 
       - name: Create or update release PR
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN != '' && secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_PAT != '' && secrets.RELEASE_PLZ_PAT || secrets.RELEASE_PLZ_TOKEN != '' && secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
 
   release:
     name: release
     runs-on: ubuntu-latest
     needs: release-pr
+    env:
+      RELEASE_PLZ_PAT: ${{ secrets.RELEASE_PLZ_PAT }}
+      RELEASE_PLZ_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Warn when RELEASE_PLZ_TOKEN is unset
-        if: ${{ secrets.RELEASE_PLZ_TOKEN == '' }}
+      - name: Warn when release-plz PAT is unset
         run: |
-          echo "::warning::RELEASE_PLZ_TOKEN is not set; tag-driven workflows may not trigger."
-          echo "::warning::Set RELEASE_PLZ_TOKEN (PAT with repo contents/pull_request write) for full automation."
+          if [ -z "${RELEASE_PLZ_PAT}" ] && [ -z "${RELEASE_PLZ_TOKEN}" ]; then
+            echo "::warning::Neither RELEASE_PLZ_PAT nor RELEASE_PLZ_TOKEN is set; tag-driven workflows may not trigger."
+            echo "::warning::Set RELEASE_PLZ_PAT (preferred) as a PAT with repo contents + pull_request write permissions."
+          fi
 
       - name: Create tags for merged release PRs
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN != '' && secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_PAT != '' && secrets.RELEASE_PLZ_PAT || secrets.RELEASE_PLZ_TOKEN != '' && secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}

--- a/book/src/reference/releasing.md
+++ b/book/src/reference/releasing.md
@@ -34,7 +34,7 @@ Tag pushes (`v*`) trigger the binary release workflow.
 3. Run CI-parity commands (`just ci-local`; optionally compiled e2e checks).
 4. Validate distribution metadata templates (`just dist-metadata-check`).
 5. Confirm PR checks (`gh pr checks <pr-number>`).
-6. Ensure `RELEASE_PLZ_TOKEN` secret is configured with `contents` + `pull_requests` write permission.
+6. Ensure `RELEASE_PLZ_PAT` secret is configured with `contents` + `pull_requests` write permission (`RELEASE_PLZ_TOKEN` is also supported as a fallback name).
 7. If default-branch protection blocks workflow pushes, set `JOY_RELEASE_PAT` so release metadata commits can update `Formula/joy.rb`.
 
 ## Automated Flow (Recommended)


### PR DESCRIPTION
## Summary
- fix release-plz workflow parsing by removing `secrets` usage from step-level `if` expressions
- support both `RELEASE_PLZ_PAT` (preferred) and `RELEASE_PLZ_TOKEN` for release-plz auth
- update releasing docs to match the configured secret name

## Root Cause
GitHub Actions does not allow `secrets` context in `if` expressions for this workflow parse path, so `.github/workflows/release-plz.yaml` failed to load and exited in 0s with no jobs.

## Validation
- `just ci-docs`
- `gh workflow run release-plz.yaml --ref codex/fix-release-plz-workflow-parse`
- Successful dispatch run: https://github.com/harnesslabs/joy/actions/runs/22678688634
