### PR TITLE
fix(release): use supported intel macOS runner label

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
             target: aarch64-apple-darwin
             archive_ext: tar.gz
             binary_name: joy
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             archive_ext: tar.gz
             binary_name: joy
@@ -140,7 +140,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             archive_ext: tar.gz
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             archive_ext: tar.gz
           - os: windows-latest


### PR DESCRIPTION
## Summary
- replace `macos-13` with `macos-15-intel` in release artifact and smoke-test matrices
- keep `x86_64-apple-darwin` artifact coverage while using a supported hosted runner label

## Why
The current release workflow fails early on Intel macOS with:
`The configuration 'macos-13-us-default' is not supported`.

## Validation
- workflow YAML parse for `.github/workflows/release.yaml`
