### PR TITLE
fix(release): unblock v0.1.1 publish workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,8 +196,17 @@ jobs:
 
       - name: Generate CycloneDX SBOM
         run: |
-          cargo cyclonedx --workspace --all-features --format json --override-filename joy-sbom
-          cp joy-sbom.cdx.json dist-joy-sbom.cdx.json
+          set -euo pipefail
+          cargo cyclonedx --all-features --format json --override-filename joy-sbom
+          if [ -f joy-sbom.cdx.json ]; then
+            cp joy-sbom.cdx.json dist-joy-sbom.cdx.json
+          elif [ -f joy-sbom.json ]; then
+            cp joy-sbom.json dist-joy-sbom.cdx.json
+          else
+            echo "CycloneDX output file not found." >&2
+            ls -la
+            exit 1
+          fi
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4
@@ -324,7 +333,7 @@ jobs:
               "github": "https://github.com/harnesslabs/joy"
             },
             "autoupdate": {
-              "url": "https://github.com/harnesslabs/joy/releases/download/v$version/joy-v$version-x86_64-pc-windows-msvc.zip"
+              "url": "https://github.com/harnesslabs/joy/releases/download/v\$version/joy-v\$version-x86_64-pc-windows-msvc.zip"
             }
           }
           SCOOP


### PR DESCRIPTION
## Summary
- fix SBOM step to use current cargo-cyclonedx CLI (drop unsupported --workspace)
- handle both supported output filenames (joy-sbom.cdx.json and joy-sbom.json)
- escape Scoop autoupdate `` placeholders so bash `set -u` does not fail

## Why
The v0.1.0 release workflow failed before publishing because:
- \ is no longer accepted
- Scoop metadata generation expanded \ as an unset shell variable

## Validation
- ran the updated SBOM shell block locally and confirmed \ is produced
- validated the escaped Scoop URL generation pattern under \