### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/harnesslabs/joy/compare/v0.1.0...v0.1.1) - 2026-03-04
+
+### Fixed
+
+- *(release)* unblock sbom and scoop metadata generation ([#153](https://github.com/harnesslabs/joy/pull/153))
+
 ### Added
 
 - Production-readiness baseline hardening:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "joy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "joy"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION



## 🤖 New release

* `joy`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/harnesslabs/joy/compare/v0.1.0...v0.1.1) - 2026-03-04

### Fixed

- *(release)* unblock sbom and scoop metadata generation ([#153](https://github.com/harnesslabs/joy/pull/153))

### Added

- Production-readiness baseline hardening:
- CI gating updates (required/optional split, docs checks, semver advisory baseline)
- JSON machine envelope metadata (`schema_version`, `joy_version`)
- `joy version` command
- `joy outdated --sources` source filtering
- GitHub tag-based update checks in `joy outdated`
- Release artifact smoke tests and generated packaging metadata assets
- Governance baseline docs (`LICENSE`, `SECURITY.md`, `CODE_OF_CONDUCT.md`)

### Changed

- mdBook configuration updated for modern `mdbook` compatibility
- Default registry URL fallback now points to the public default registry when `JOY_REGISTRY_DEFAULT` is unset
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).