### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/harnesslabs/joy/compare/v0.1.1...v0.1.2) - 2026-03-05
+
+### Fixed
+
+- *(release)* avoid same-file copy in github-release job ([#155](https://github.com/harnesslabs/joy/pull/155))
+
+### Other
+
+- deletion-first simplification pass ([#156](https://github.com/harnesslabs/joy/pull/156))
+
 ## [0.1.1](https://github.com/harnesslabs/joy/compare/v0.1.0...v0.1.1) - 2026-03-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "joy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -991,7 +991,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "joy"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION



## 🤖 New release

* `joy`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/harnesslabs/joy/compare/v0.1.1...v0.1.2) - 2026-03-05

### Fixed

- *(release)* avoid same-file copy in github-release job ([#155](https://github.com/harnesslabs/joy/pull/155))

### Other

- deletion-first simplification pass ([#156](https://github.com/harnesslabs/joy/pull/156))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).