### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/harnesslabs/joy/compare/v0.1.2...v0.2.0) - 2026-03-06
+
+### Added
+
+- phase87-92 source parity and remote registry publish transport ([#181](https://github.com/harnesslabs/joy/pull/181))
+- phase77-86 cargo/uv-grade usability wave ([#179](https://github.com/harnesslabs/joy/pull/179))
+
+### Other
+
+- *(book)* recover mdbook parity and add playbook ([#182](https://github.com/harnesslabs/joy/pull/182))
+
 ## [0.1.2](https://github.com/harnesslabs/joy/compare/v0.1.1...v0.1.2) - 2026-03-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,12 +1375,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2051,9 +2051,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION



## 🤖 New release

* `joy`: 0.1.2 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/harnesslabs/joy/compare/v0.1.2...v0.2.0) - 2026-03-06

### Added

- phase87-92 source parity and remote registry publish transport ([#181](https://github.com/harnesslabs/joy/pull/181))
- phase77-86 cargo/uv-grade usability wave ([#179](https://github.com/harnesslabs/joy/pull/179))

### Other

- *(book)* recover mdbook parity and add playbook ([#182](https://github.com/harnesslabs/joy/pull/182))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).